### PR TITLE
Сделал отступ в описании типов

### DIFF
--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -3,7 +3,7 @@ import type { RootState } from '../store/app';
 
 interface UseUserInfo {
     userName: string | null
-    userInfo: string| null
+    userInfo: string | null
 }
 
 export function useUserInfo(): UseUserInfo {


### PR DESCRIPTION
В файле `src/hooks/useUserInfo.ts` в описании поля интерфейса `userInfo` добавил пробел между типами